### PR TITLE
Fix null reference error when spell definition is missing

### DIFF
--- a/Chrome/js/popup.js
+++ b/Chrome/js/popup.js
@@ -1,4 +1,4 @@
-﻿document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', function () {
     // Fetch character info when the button is clicked
     document.getElementById('fetchButton').addEventListener('click', function () {
         showSpinner();
@@ -1304,6 +1304,9 @@ function gatherSpells(data, characterData) {
         for (let i = 0; i < data.spells[area].length; i++) {
             const spell = data.spells[area][i];
             const definition = spell.definition;
+            if (definition == null){
+                continue;
+            }
             const activation = definition.activation;
             const duration = definition.duration;
 


### PR DESCRIPTION
## Summary

- Added null check for `spell.definition` in `gatherSpells()` before accessing `activation` and `duration` properties
- Prevents a crash when a spell entry exists in the data but has no definition populated

## Root Cause

When iterating over spells, some entries can have a `null` definition. Accessing `.activation` or `.duration` on `null` throws a TypeError. The fix skips those entries with an early `continue`.

## Test plan

- [ ] Load a character that has spells with missing definitions and verify no crash occurs
- [ ] Verify normal spells still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)